### PR TITLE
Replacing "presenter" references with "leaf"

### DIFF
--- a/src/SelectionControls/CheckSet/CheckSetView.php
+++ b/src/SelectionControls/CheckSet/CheckSetView.php
@@ -28,7 +28,7 @@ class CheckSetView extends SetSelectionControlView
     {
         $checked = ($this->isValueSelected($value)) ? ' checked="checked"' : '';
 
-        return '<input type="checkbox" name="' . htmlentities($name) . '[]" value="' . htmlentities($value) . '" presenter-name="' . htmlentities($this->presenterName) . '" id="' . htmlentities($this->getInputId($name,
+        return '<input type="checkbox" name="' . htmlentities($name) . '[]" value="' . htmlentities($value) . '" leaf-name="' . htmlentities($this->model->leafName) . '" id="' . htmlentities($this->getInputId($name,
             $value)) . '"' . $checked . '>';
     }
 


### PR DESCRIPTION
Old references to presenter have now been replaced with references to leaf, and leafName is accessed through the model.
