### PR TITLE
Changing parseRequest() for checkboxes who are printed with index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.0.37
+
+* Fixed:    Bug where checkboxes printed with index didn't send false when they were unchecked.  
+
 ### 1.0.36
 
 * Added:    Disabling radio buttons is now a thing

--- a/src/Checkbox/CheckboxView.php
+++ b/src/Checkbox/CheckboxView.php
@@ -27,7 +27,7 @@ class CheckboxView extends ControlView
      */
     private function getPresenceInputName()
     {
-        return "set_{$this->model->leafPath}_";
+        return 'set_' . $this->model->leafPath;
     }
 
     /**
@@ -71,12 +71,13 @@ class CheckboxView extends ControlView
         // update our model.
 
         $postData = $request->postData;
-
+        $checked = [];
         foreach ($postData as $key => $value) {
-            if (preg_match("/" . $path . "\(([^)]+)\)$/", $key, $match)) {
+            if (preg_match("/^" . $path . "\((.+?)\)$/", $key, $match)) {
+                $checked[] = $match[1];
                 $this->setControlValueForIndex($match[1], true);
             } else {
-                if (preg_match("/" . $this->getPresenceInputName() . "\(([^)]+)\)$/", $key, $match)) {
+                if (preg_match("/^" . $this->getPresenceInputName() . "\((.+?)\)$/", $key, $match) && !in_array($match[1], $checked)) {
                     $this->setControlValueForIndex($match[1], false);
                 }
             }


### PR DESCRIPTION
Due to the previous `getPresenceInputName()`, where _ was appended to the leaf path, the regex was wrong as the index would be printed before the _

The trailing underscore was previously used to prevent the regex from matching in the first `if`, so this was changed to ensure that it only matched from the start of the string.

We then keep track of which ones have been marked as true, to ensure we don't mark them as false afterwards.